### PR TITLE
added functionality related to log type and pod information

### DIFF
--- a/server/controllers/logController.ts
+++ b/server/controllers/logController.ts
@@ -1,8 +1,13 @@
 const fs = require('fs');
 
-const logController : any = {};
+// non-pod log types
+const sourceTypes = ['apiserver', 'etcd', 'controller-manager', 'proxy', 'scheduler', 'coredns', 'storage-provisioner'];
+
+const logController : any = { sourceTypes: sourceTypes };
 
 logController.parseLogs = (req, res, next) => {
+  const pods = {};
+
   fs.readFile('/Users/charlesfrancofranco/Documents/logs/my-app-copy.19700101.log.txt_26.log', 'utf-8', (err, readData) => {
     if (err) {
         return res.status(500).json({ error: 'Failed to read log file' });
@@ -12,31 +17,64 @@ logController.parseLogs = (req, res, next) => {
   
     const logEntries = logData.map(line => {
       // Define a regular expression pattern to match the components
-      const regexPattern = /^(\S+)\s+(\S+)\s+(.*$)/;
-      const match = line.match(regexPattern);
+      const logEntryPattern = /^(\S+)\s+(\S+)\s+(.*$)/;
+      const match = line.match(logEntryPattern);
   
       if (match) {
-          const timestamp = match[1];
-          const sourceInfo = match[2];
-          const logData = match[3];
-  
-          try {
-              const logObject = JSON.parse(logData);
-              return {
-                  timestamp,
-                  sourceInfo,
-                  logObject,
-              };
-          } catch (e) {
-              console.error('Error parsing log JSON:', e);
-              return null;
-          }
+        const timestamp = match[1];
+        const sourceInfo = match[2];
+        const logData = match[3];
+
+        let type;
+        const podInfo : any = {};
+
+        // see if type is not a pod log
+        for (let i = 0; i < logController.sourceTypes.length; i++) {
+          if (sourceInfo.includes(logController.sourceTypes[i])) {
+            type = logController.sourceTypes[i];
+            break;
+          } 
+        } 
+        
+        if (!type) {
+          type = "pod";
+          const sourceInfoPattern = /kubernetes\.var\.log\.containers\.([^_]+)_([^_]+)_([^\.]+)\.log/;
+          const match = sourceInfo.match(sourceInfoPattern);
+      
+          if (match) {
+            podInfo.podName = match[1];
+            
+            // Populates pods obj with the podName, which might need to be converted to a count down the road of functionality calls for it
+            if (!pods.hasOwnProperty(match[1])){
+              pods[match[1]] = match[1];
+            }
+
+            podInfo.namespace = match[2];
+            podInfo.containerName = match[3];
+          };
+        };
+
+        try {
+            const logObject = JSON.parse(logData);
+            return {
+                timestamp,
+                sourceInfo,
+                type,
+                podInfo,
+                logObject
+            };
+        } catch (e) {
+            console.error('Error parsing log JSON:', e);
+            return null;
+        }
       } else {
-          // Handle lines that don't match the expected format
-          return null;
+        // Handle lines that don't match the expected format
+        return null;
       }
-    })
+    });
+    // assign res.locals.data to logEntries
     res.locals.data = logEntries;
+    // return invocation of next
     return next();
   });
 };


### PR DESCRIPTION
##Overview
**Issue Type**
- [] Bug
- [x] Feature
- []Tech debt

**Description**
With each line that is read from the log file, there is now algorithmic logic in place to identify the type of log, which will be used on the frontend for filtering. When a `pod` type is logged, a `podInfo` object is populated with information related to the pod's name, its namespace, and its container name.

**Steps to Reproduce Bug/Validate Feature/Confirm Tech Debt Fix**
Retrieved information in JSON format when sending via Postman.

**Previous Behavior**
N/A

**Expected Behavior**
N/A

**How Has This Been Tested**
N/A

**Screenshots & Videos**
N/A 

**Additional Context**
N/A